### PR TITLE
Node@18을 지원범위에 추가합니다.

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,1 @@
+* @NaverPayDev/frontend

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Shareable Browserslist config for naverpay
 
-지원범위: [>0.2%,not dead,not op_mini all,not ie>=0,not ios_saf<15,ios_saf>=15](https://browsersl.ist/#q=%3E0.2%25%2Cnot+dead%2Cnot+op_mini+all%2Cnot+ie%3E%3D0%2Cnot+ios_saf%3C15%2Cios_saf%3E%3D15&region=KR)
+지원범위: [>0.2%,not dead,not op_mini all,not ie>=0,not ios_saf<15,ios_saf>=15,node>=18.18.0](https://browsersl.ist/#q=%3E0.2%25%2Cnot+dead%2Cnot+op_mini+all%2Cnot+ie%3E%3D0%2Cnot+ios_saf%3C15%2Cios_saf%3E%3D15%2Cnode%3E%3D18.18.0&region=KR)

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const NAVERPAY_SUPPORTED_BROWSER_LIST = [
   "not ie >= 0",
   "not ios_saf < 15",
   "ios_saf >= 15",
+  "node >= 18.18.0",
 ];
 
 module.exports = NAVERPAY_SUPPORTED_BROWSER_LIST;


### PR DESCRIPTION
## why

- node@16 은 죽었습니다
- 가장 많이 쓰는 프레임워크 중, next 지원 범위가 가장 엄격해서 (18.18) 그 기준을 따릅니다.