### PR TITLE
브라우저 지원 범위 업데이트

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -6,8 +6,8 @@
 
 이 패키지는 NAVERPAY 프론트엔드가 개발한 서비스에서 사용할 **공식 지원 브라우저/Node.js 버전** 목록을 일관되게 관리할 수 있는 환경을 제공합니다.
 
-**Current support range:**  
-[>0.2%, not dead, not op_mini all, not ie >= 0, not ios_saf < 15, ios_saf >= 15, node >= 18.18.0, Chrome >= 106](https://browsersl.ist/#q=%3E0.2%25%2Cnot+dead%2Cnot+op_mini+all%2Cnot+ie%3E%3D0%2Cnot+ios_saf%3C15%2Cios_saf%3E%3D15%2Cnode%3E%3D18.18.0%2CChrome%3E%3D106&region=KR)
+**현재 지원 범위:**
+[>= 1%, not dead, not op_mini all, not ie >= 0, not ios_saf < 16, ios_saf >= 16, node >= 18.18.0, Chrome >= 106](https://browsersl.ist/#q=%3E%3D+1%25%2C+not+dead%2C+not+op_mini+all%2C+not+ie+%3E%3D+0%2C+not+ios_saf+%3C+16%2C+ios_saf+%3E%3D+16%2C+node+%3E%3D+18.18.0%2C+Chrome+%3E%3D+106&region=KR)
 
 ## 설치
 
@@ -44,18 +44,18 @@ extends @naverpay/browserslist-config
 - Node.js 18.18.0 이상
 - Chrome 106 이상
 
-최신 지원 브라우저 전체 리스트는 아래에서 확인할 수 있습니다.  
+최신 지원 브라우저 전체 리스트는 아래에서 확인할 수 있습니다.
 [browsersl.ist 쿼리 (KR)](https://browsersl.ist/#q=%3E0.2%25%2Cnot+dead%2Cnot+op_mini+all%2Cnot+ie%3E%3D0%2Cnot+ios_saf%3C15%2Cios_saf%3E%3D15%2Cnode%3E%3D18.18.0%2CChrome%3E%3D106&region=KR)
 
 ## 자주 묻는 질문
 
-**Q: 왜 공유 설정을 사용하나요?**  
+**Q: 왜 공유 설정을 사용하나요?**
 A: 모든 NAVERPAY 프론트엔드가 동일한 브라우저 정책을 따르도록 보장하며, 설정 중복과 실수를 방지합니다.
 
-**Q: 업데이트 주기는?**  
+**Q: 업데이트 주기는?**
 A: 비즈니스/프로젝트의 요구나 브라우저의 시장환경 변화에 따라 변경됩니다. 자세한 변경사항은 CHANGELOG를 참고하세요.
 
-**Q: 실제 지원 브라우저를 확인하려면?**  
+**Q: 실제 지원 브라우저를 확인하려면?**
 A:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 This package provides a unified and maintainable list of supported browsers and Node.js versions for all NAVERPAY frontend services.
 
-**Current support range:**  
-[>0.2%, not dead, not op_mini all, not ie >= 0, not ios_saf < 15, ios_saf >= 15, node >= 18.18.0, Chrome >= 106](https://browsersl.ist/#q=%3E0.2%25%2Cnot+dead%2Cnot+op_mini+all%2Cnot+ie%3E%3D0%2Cnot+ios_saf%3C15%2Cios_saf%3E%3D15%2Cnode%3E%3D18.18.0%2CChrome%3E%3D106&region=KR)
+**Current support range:**
+[>= 1%, not dead, not op_mini all, not ie >= 0, not ios_saf < 16, ios_saf >= 16, node >= 18.18.0, Chrome >= 106](https://browsersl.ist/#q=%3E%3D+1%25%2C+not+dead%2C+not+op_mini+all%2C+not+ie+%3E%3D+0%2C+not+ios_saf+%3C+16%2C+ios_saf+%3E%3D+16%2C+node+%3E%3D+18.18.0%2C+Chrome+%3E%3D+106&region=KR)
 
 ## Installation
 
@@ -44,18 +44,18 @@ extends @naverpay/browserslist-config
 - Node.js 18.18.0+
 - Chrome 106+
 
-See the full, up-to-date list here:  
+See the full, up-to-date list here:
 [browsersl.ist Query (KR)](https://browsersl.ist/#q=%3E0.2%25%2Cnot+dead%2Cnot+op_mini+all%2Cnot+ie%3E%3D0%2Cnot+ios_saf%3C15%2Cios_saf%3E%3D15%2Cnode%3E%3D18.18.0%2CChrome%3E%3D106&region=KR)
 
 ## FAQ
 
-**Q: Why use a shared Browserslist config?**  
+**Q: Why use a shared Browserslist config?**
 A: It ensures every @naverpay/frontend project follows the same browser support policy—less redundancy, fewer mistakes.
 
-**Q: How often is it updated?**  
+**Q: How often is it updated?**
 A: As the business/project requirements or browser landscape changes. Check CHANGELOG for details.
 
-**Q: How do I check the resolved browser list?**  
+**Q: How do I check the resolved browser list?**
 A:
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 const NAVERPAY_SUPPORTED_BROWSER_LIST = [
-  ">0.2%",
+  ">= 1%",
   "not dead",
   "not op_mini all",
   "not ie >= 0",
-  "not ios_saf < 15",
-  "ios_saf >= 15",
+  "not ios_saf < 16",
+  "ios_saf >= 16",
   "node >= 18.18.0",
-  "Chrome>=106",
+  "Chrome >= 106",
 ];
 
 module.exports = NAVERPAY_SUPPORTED_BROWSER_LIST;


### PR DESCRIPTION
## 변경사항

- 브라우저 지원범위를 16으로 업데이트 합니다
- 브라우저 지원 범위를 1% 로 올립니다.

- https://browsersl.ist/#q=%3E0.2%25%2Cnot+dead%2Cnot+op_mini+all%2Cnot+ie%3E%3D0%2Cnot+ios_saf%3C15%2Cios_saf%3E%3D15%2Cnode%3E%3D18.18.0%2CChrome%3E%3D106&region=KR
- https://browsersl.ist/#q=%3E%3D+1%25%2C+not+dead%2C+not+op_mini+all%2C+not+ie+%3E%3D+0%2C+not+ios_saf+%3C+16%2C+ios_saf+%3E%3D+16%2C+node+%3E%3D+18.18.0%2C+Chrome+%3E%3D+106&region=KR

## 차이

- 큰차이없음