### PR TITLE
iOS Safari >= 17, Node.js >= 20.12.0 지원 범위 업데이트

### DIFF
--- a/.changeset/empty-geese-camp.md
+++ b/.changeset/empty-geese-camp.md
@@ -1,0 +1,7 @@
+---
+"@naverpay/browserslist-config": major
+---
+
+iOS Safari >= 17, Node.js >= 20.12.0 지원 범위 업데이트
+
+PR: [iOS Safari >= 17, Node.js >= 20.12.0 지원 범위 업데이트](https://github.com/NaverPayDev/browserslist-config/pull/21)

--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ const NAVERPAY_SUPPORTED_BROWSER_LIST = [
   "not dead",
   "not op_mini all",
   "not ie >= 0",
-  "not ios_saf < 16",
-  "ios_saf >= 16",
+  "not ios_saf < 17",
+  "ios_saf >= 17",
   "node >= 18.18.0",
   "Chrome >= 106",
 ];

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const NAVERPAY_SUPPORTED_BROWSER_LIST = [
   "not ie >= 0",
   "not ios_saf < 17",
   "ios_saf >= 17",
-  "node >= 18.18.0",
+  "node >= 20.12.0",
   "Chrome >= 106",
 ];
 


### PR DESCRIPTION
## 변경 사항

브라우저/런타임 지원 범위를 업데이트합니다.

### iOS Safari
- `ios_saf >= 16` → `ios_saf >= 17`

### Node.js
- `node >= 18.18.0` → `node >= 20.12.0`
  - 주요 보안 패치 및 성능 최적화가 함께 이루어진 버전부터 지원
  - Node.js 18은 2025-04 EOL
  - Node.js 20은 2026-04 EOL 예정

## 변경 파일
- `index.js`: 지원 브라우저 목록 쿼리 값 수정